### PR TITLE
Add ProjectName to StackdriverAlertQuery struct

### DIFF
--- a/alert.go
+++ b/alert.go
@@ -74,6 +74,7 @@ type AlertModel struct {
 }
 
 type StackdriverAlertQuery struct {
+	ProjectName        string                    `json:"projectName,omitempty"`
 	AlignOptions       []StackdriverAlignOptions `json:"alignOptions,omitempty"`
 	AliasBy            string                    `json:"aliasBy,omitempty"`
 	MetricType         string                    `json:"metricType,omitempty"`


### PR DESCRIPTION
Enable setting of the GCP project name on Stackdriver Alerts. This change enables an alert on a dashboard to reference another GCP project just like a panel can already.