### PR TITLE
feat(alert): add missing gcm fields

### DIFF
--- a/alert.go
+++ b/alert.go
@@ -71,6 +71,12 @@ type AlertModel struct {
 
 	// For Stackdriver
 	MetricQuery *StackdriverAlertQuery `json:"metricQuery,omitempty"`
+
+	// For Cloudmonitoring.
+	TimeSeriesList  *GCMTimeSeriesList  `json:"timeSeriesList,omitempty"`
+	TimeSeriesQuery *GCMTimeSeriesQuery `json:"timeSeriesQuery,omitempty"`
+	PromQLQuery     *GCMPromQLQuery     `json:"promQLQuery,omitempty"`
+	SLOQuery        *GCMSLOQuery        `json:"sloQuery,omitempty"`
 }
 
 type StackdriverAlertQuery struct {


### PR DESCRIPTION
### What does this PR do?

#29 was lacking the alert integration, this PR adresses that.